### PR TITLE
Initial Version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/target
+**/*.rs.bk
+Cargo.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: rust
+rust: nightly
+cache: cargo
+
+addons:
+  apt:
+    sources:
+      - llvm-toolchain-trusty-6.0
+      - ubuntu-toolchain-r-test
+    packages:
+      - clang-6.0
+      - clang-tools-6.0
+      - clang-6.0-doc
+      - libclang-common-6.0-dev
+      - libclang-6.0-dev
+      - libclang1-6.0
+      - libllvm6.0
+      - llvm-6.0
+      - llvm-6.0-dev
+      - llvm-6.0-doc
+      - llvm-6.0-examples
+      - llvm-6.0-runtime
+      - clang-format-6.0
+      - python-clang-6.0
+      - lld-6.0
+      - libfuzzer-6.0-dev
+
+before_script:
+    - export PATH="$PATH:$HOME/.cargo/bin"
+
+script:
+    - cargo build --examples
+    - cargo doc --no-deps
+    - cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "ykstackmaps"
+version = "0.1.0"
+authors = ["Edd Barrett <vext01@gmail.com>"]
+
+[dependencies]
+elf = "0.0"
+byteorder = "1.2"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,94 @@
+// Copyright (c) 2018 King's College London
+// Created by the Software Development Team <http://soft-dev.org/>
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any
+// person obtaining a copy of this software, associated documentation and/or
+// data (collectively the "Software"), free of charge and under any and all
+// copyright rights in the Software, and any and all patent rights owned or
+// freely licensable by each licensor hereunder covering either (i) the
+// unmodified Software as contributed to or provided by such licensor, or (ii)
+// the Larger Works (as defined below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
+// if one is included with the Software (each a "Larger Work" to which the Software
+// is contributed by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create
+// derivative works of, display, perform, and distribute the Software and make,
+// use, sell, offer for sale, import, export, have made, and have sold the
+// Software and the Larger Work(s), and to sublicense the foregoing rights on
+// either these or other terms.
+//
+// This license is subject to the following condition: The above copyright
+// notice and either this complete permission notice or at a minimum a reference
+// to the UPL must be included in all copies or substantial portions of the
+// Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use std::error::Error;
+use std::fmt::{self, Formatter, Display};
+use std::io;
+use elf;
+
+#[derive(Debug)]
+pub enum SMParserError {
+    /// Parse error from the elf library.
+    ElfParse(elf::ParseError),
+    /// Generic IO error.
+    IO(io::Error),
+    /// Other error.
+    Other(String),
+}
+
+impl Display for SMParserError {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            SMParserError::ElfParse(e) => write!(f, "{:?}", e), // `e` doesn't implement `Display`.
+            SMParserError::IO(e) => Display::fmt(e, f),
+            SMParserError::Other(s) => write!(f, "{}", s),
+        }
+    }
+}
+
+impl Error for SMParserError {
+    fn description(&self) -> &str {
+        match self {
+            SMParserError::ElfParse(_) => "ELF parse error",
+            SMParserError::IO(e) => e.description(),
+            SMParserError::Other(_) => "Other ykstackmaps error",
+        }
+    }
+
+    fn cause(&self) -> Option<&Error> {
+        match self {
+            SMParserError::ElfParse(_) => None, // Doesn't implement `Error`.
+            SMParserError::IO(ref e) => Some(e),
+            SMParserError::Other(_) => None,
+        }
+    }
+
+}
+
+impl From<io::Error> for SMParserError {
+    fn from(e: io::Error) -> Self {
+        SMParserError::IO(e)
+    }
+}
+
+impl From<elf::ParseError> for SMParserError {
+    fn from(e: elf::ParseError) -> Self {
+        SMParserError::ElfParse(e)
+    }
+}
+
+pub (crate) type SMParserResult<T> = Result<T, SMParserError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,463 @@
+// Copyright (c) 2018 King's College London
+// Created by the Software Development Team <http://soft-dev.org/>
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any
+// person obtaining a copy of this software, associated documentation and/or
+// data (collectively the "Software"), free of charge and under any and all
+// copyright rights in the Software, and any and all patent rights owned or
+// freely licensable by each licensor hereunder covering either (i) the
+// unmodified Software as contributed to or provided by such licensor, or (ii)
+// the Larger Works (as defined below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
+// if one is included with the Software (each a "Larger Work" to which the Software
+// is contributed by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create
+// derivative works of, display, perform, and distribute the Software and make,
+// use, sell, offer for sale, import, export, have made, and have sold the
+// Software and the Larger Work(s), and to sublicense the foregoing rights on
+// either these or other terms.
+//
+// This license is subject to the following condition: The above copyright
+// notice and either this complete permission notice or at a minimum a reference
+// to the UPL must be included in all copies or substantial portions of the
+// Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Parse the stackmap section of an ELF binary containing stackmap records.
+//
+// The comments in this file reference the "Stack Map Format" section of the LLVM documentation
+// found here:
+// https://llvm.org/docs/StackMaps.html#stack-map-format
+
+extern crate elf;
+extern crate byteorder;
+
+mod errors;
+#[macro_use]
+mod util;
+
+use std::path::Path;
+use std::io::Cursor;
+use byteorder::{NativeEndian, ReadBytesExt};
+use errors::{SMParserError, SMParserResult};
+use util::{cursor_skip, cursor_align8, cursor_from_elf};
+
+// We only support this version of the stackmap header for now.
+const STACKMAP_VERSION: u8 = 3;
+
+// Sizes in bytes.
+const SIZE_STACK_SIZE_ENTRY: u8 = 24;
+const SIZE_CONSTANT_ENTRY: u8 = 8;
+const SIZE_LOC_ENTRY: u8 = 12;
+const SIZE_LIVEOUT_ENTRY: u8 = 4;
+
+/// Offsets into the stackmap section.
+const OFFS_STACK_SIZE_ENTRIES: u64 = 16;
+
+/// Represents a single stackmap record entry.
+#[derive(Debug, Eq, PartialEq)]
+pub struct SMRec {
+    id: u64,            // Stackmap ID.
+    offset: u32,        // Stackmap offset from start of containing func.
+}
+
+impl SMRec {
+    /// Returns the stackmap ID.
+    pub fn id(&self) -> u64 {
+        self.id
+    }
+
+    /// Returns the offset of the stackmap from the start of the containing function.
+    pub fn offset(&self) -> u32 {
+        self.offset
+    }
+}
+
+/// Represents a single function entry.
+#[derive(Debug, Eq, PartialEq)]
+pub struct SMFunc {
+    addr: u64,          // Function address.
+    stack_size: u64,    // Function's stack size.
+}
+
+impl SMFunc {
+    /// Get the function address.
+    pub fn addr(&self) -> u64 {
+        self.addr
+    }
+
+    /// Get the size of the stack of the function.
+    pub fn stack_size(&self) -> u64 {
+        self.stack_size
+    }
+}
+
+/// An iterator over stackmap record entries.
+pub struct SMRecIterator<'a> {
+    elf_file: &'a elf::File,
+    cursor: Option<Cursor<&'a Vec<u8>>>, // Lazily created so that creating the iterator doesn't
+                                         // need to return a `Result`.
+    start_pos: u64,                      // Start position of the cursor.
+    num_stackmaps: u32,
+}
+
+impl<'a> Iterator for SMRecIterator<'a> {
+    type Item = SMParserResult<SMRec>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.num_stackmaps == 0 {
+            return None;
+        }
+
+        if self.cursor.is_none() {
+            self.cursor = Some(itry!(cursor_from_elf(self.elf_file, self.start_pos)));
+        }
+        let mut cursor = self.cursor.as_mut().unwrap();
+
+        // StkMapRecord[NumRecords] {
+        //     uint64: PatchPoint ID
+        let sm_id = itry!(cursor.read_u64::<NativeEndian>());
+        //     uint32: Instruction Offset
+        let sm_offset = itry!(cursor.read_u32::<NativeEndian>());
+
+        // At this point we have everything we need from this entry, but need to skip the remainder
+        // of the (variable-sized) entry to find the start of the next.
+
+        //     uint16: Reserved (record flags)
+        itry!(cursor_skip(&mut cursor, 2));
+
+        //     uint16: NumLocations
+        let num_locs = itry!(cursor.read_u16::<NativeEndian>());
+        //     Location[NumLocations] { ... }
+        let skip_locs_sz = u64::from(u32::from(num_locs) * u32::from(SIZE_LOC_ENTRY));
+        itry!(cursor_skip(&mut cursor, skip_locs_sz as i64));
+        //     uint32: Padding (only if required to align to 8 byte)
+        //     uint16: Padding
+        itry!(cursor_align8(&mut cursor));
+
+        //     uint16: NumLiveOuts
+        let num_liveouts = itry!(cursor.read_u16::<NativeEndian>());
+        //     LiveOuts[NumLiveOuts] { ... }
+        let skip_liveouts_len = i64::from(num_liveouts) * i64::from(SIZE_LIVEOUT_ENTRY);
+        itry!(cursor_skip(&mut cursor, skip_liveouts_len));
+
+        //     uint32: Padding (only if required to align to 8 byte)
+        itry!(cursor_align8(&mut cursor));
+        // } -- End of this stackmap record.
+
+        self.num_stackmaps -= 1;
+        Some(Ok(SMRec{id: sm_id, offset: sm_offset}))
+    }
+}
+
+/// An iterator over function entries.
+pub struct SMFuncIterator<'a> {
+    elf_file: &'a elf::File,
+    cursor: Option<Cursor<&'a Vec<u8>>>, // Lazily created so that creating the iterator doesn't
+                                         // need to return a `Result`.
+    start_pos: u64,                      // Start position of the cursor.
+    num_funcs: u32,
+}
+
+impl<'a> Iterator for SMFuncIterator<'a> {
+    type Item = SMParserResult<SMFunc>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.num_funcs == 0 {
+            return None;
+        }
+
+        if self.cursor.is_none() {
+            self.cursor = Some(itry!(cursor_from_elf(self.elf_file, self.start_pos)));
+        }
+        let cursor = self.cursor.as_mut().unwrap();
+
+        // StkSizeRecord[NumFunctions] {
+        //     uint64: Function Address
+        let addr = itry!(cursor.read_u64::<NativeEndian>());
+        //     uint64: Stack Size
+        let stack_size = itry!(cursor.read_u64::<NativeEndian>());
+        //     uint64: Record Count
+        itry!(cursor_skip(cursor, 8));
+        // } -- End of this function entry.
+
+        self.num_funcs -= 1;
+        Some(Ok(SMFunc{addr, stack_size}))
+    }
+}
+
+/// Top-level struct through which the user interfaces with the stackmap section.
+pub struct StackMapParser {
+    elf_file: elf::File,
+    num_funcs: u32,
+    num_consts: u32,
+    num_stackmaps: u32,
+}
+
+impl StackMapParser {
+    pub fn new(path: &Path) -> SMParserResult<Self> {
+        let elf_file = elf::File::open_path(path)?;
+        let num_funcs;
+        let num_consts;
+        let num_stackmaps;
+        {
+            let mut cursor = cursor_from_elf(&elf_file, 0)?;
+            Self::check_header(&mut cursor)?;
+
+            // Read in table sizes.
+            // uint32: NumFunctions
+            num_funcs = cursor.read_u32::<NativeEndian>()?;
+            // uint32: NumConstants
+            num_consts = cursor.read_u32::<NativeEndian>()?;
+            // uint32: NumRecords
+            num_stackmaps = cursor.read_u32::<NativeEndian>()?;
+        }
+
+        Ok(Self{elf_file, num_funcs, num_consts, num_stackmaps})
+    }
+
+    /// Returns the number of stackmap record entries in the stackmap section.
+    pub fn num_stackmaps(&self) -> u32 {
+        self.num_stackmaps
+    }
+
+    /// Returns the number of function entries in the stackmap section.
+    pub fn num_funcs(&self) -> u32 {
+        self.num_funcs
+    }
+
+    /// Check the stackmap header looks sane.
+    fn check_header(cursor: &mut Cursor<&Vec<u8>>) -> SMParserResult<()> {
+        // uint8: Stack Map Version
+        let version = cursor.read_u8()?;
+        if version != STACKMAP_VERSION {
+            let msg = format!("Expected stackmap format v{} but binary is v{}", STACKMAP_VERSION, version);
+            return Err(SMParserError::Other(msg));
+        }
+        // uint8: Reserved (expected to be 0)
+        let b2 = cursor.read_u8()?;
+        if b2 != 0 {
+            let msg = format!("Expected 0 in stackmap section byte 2, got {}", b2);
+            return Err(SMParserError::Other(msg));
+        }
+        // uint16: Reserved (expected to be 0)
+        let b2_3 = cursor.read_u16::<NativeEndian>()?;
+        if b2_3 != 0 {
+            let msg = format!("Expected 0 in stackmap section bytes 2 and 3, got {}", b2_3);
+            return Err(SMParserError::Other(msg));
+        }
+        Ok(())
+    }
+
+    /// Make an iterator over the stackmap record entries in the stackmap section.
+    ///
+    /// If the iterator returns an error, the iterator becomes invalid and reuse will lead to
+    /// undefined behaviour.
+    ///
+    /// # Example
+    /// ```
+    /// use std::path::Path;
+    /// use ykstackmaps::StackMapParser;
+    ///
+    /// match StackMapParser::new(&Path::new("/bin/ls")) {
+    ///     // It's unlikey /bin/ls contains stackmaps, but you get the idea.
+    ///     Err(e) => println!("error: {}", e),
+    ///     Ok(p) =>  {
+    ///         for stmap_res in p.iter_stackmaps() {
+    ///             match stmap_res {
+    ///                 Ok(stmap) => println!("{:?}", stmap),
+    ///                 Err(e) => {
+    ///                     println!("error: {}", e);
+    ///                     break; // You must not re-use the iterator upon error.
+    ///                 }
+    ///             }
+    ///         }
+    ///     }
+    /// }
+    pub fn iter_stackmaps(&self) -> SMRecIterator {
+        let start_pos = OFFS_STACK_SIZE_ENTRIES + u64::from(self.num_funcs) *
+            u64::from(SIZE_STACK_SIZE_ENTRY) + u64::from(self.num_consts) *
+            u64::from(SIZE_CONSTANT_ENTRY);
+        SMRecIterator{
+            elf_file: &self.elf_file,
+            cursor: None,
+            start_pos,
+            num_stackmaps: self.num_stackmaps
+        }
+    }
+
+    /// Make an iterator over functions defined in the stackmap section.
+    ///
+    /// If the iterator returns an error, the iterator becomes invalid and reuse will lead to
+    /// undefined behaviour.
+    ///
+    /// # Example
+    /// ```
+    /// use std::path::Path;
+    /// use ykstackmaps::StackMapParser;
+    ///
+    /// match StackMapParser::new(&Path::new("/bin/ls")) {
+    ///     // It's unlikey /bin/ls contains stackmaps, but you get the idea.
+    ///     Err(e) => println!("error: {}", e),
+    ///     Ok(p) =>  {
+    ///         for stmap_res in p.iter_functions() {
+    ///             match stmap_res {
+    ///                 Ok(stmap) => println!("{:?}", stmap),
+    ///                 Err(e) => {
+    ///                     println!("error: {}", e);
+    ///                     break; // You must not re-use the iterator upon error.
+    ///                 }
+    ///             }
+    ///         }
+    ///     }
+    /// }
+    pub fn iter_functions(&self) -> SMFuncIterator {
+        SMFuncIterator{
+            elf_file: &self.elf_file,
+            cursor: None,
+            start_pos: OFFS_STACK_SIZE_ENTRIES,
+            num_funcs: self.num_funcs,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env;
+    use std::iter::Iterator;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+    use super::{SMFunc, SMRec, StackMapParser};
+
+    const LLVM_READELF: &str = "llvm-readelf-6.0";
+
+    #[cfg(target_os="linux")]
+    const MAKE: &str = "make";
+
+    // Invokes GNU make to build a test input.
+    fn build_test_inputs(path: &PathBuf) {
+        // Change into the `test_inputs` source directory.
+        let md = env::var("CARGO_MANIFEST_DIR").unwrap();
+        let mut dir = PathBuf::from(md);
+        dir.push("test_inputs");
+        env::set_current_dir(&dir).unwrap();
+
+        // Run make.
+        let res = Command::new(MAKE)
+                          .arg(path.to_str().unwrap())
+                          .output()
+                          .unwrap();
+        if !res.status.success() {
+            eprintln!("build test input failed: \n>>> stdout");
+            eprintln!("stdout: {}", String::from_utf8_lossy(&res.stdout));
+            eprintln!("\n>>> stderr");
+            eprintln!("stderr: {}", String::from_utf8_lossy(&res.stderr));
+            panic!();
+        }
+    }
+
+    // Get the absolute path to the dir containing the test binaries.
+    fn test_bin_path(dir: &str, bin: &str) -> PathBuf {
+        let md = env::var("CARGO_MANIFEST_DIR").unwrap();
+        let mut pb = PathBuf::from(md);
+        pb.push("target");
+        pb.push("test_inputs");
+        pb.push(dir);
+        pb.push(bin);
+        pb
+    }
+
+    // Returns the left and right hand side of a comma-separated key-value pair.
+    fn parse_key_val(s: &str) -> (&str, &str) {
+        let key_val: Vec<&str> = s.split(":").collect();
+        assert_eq!(key_val.len(), 2);
+        (key_val[0].trim(), key_val[1].trim())
+    }
+
+    // Parse the output of llvm-readelf to get expected outcomes.
+    fn get_expected(path: &Path) -> (Vec<SMFunc>, Vec<SMRec>) {
+        let out = Command::new(LLVM_READELF)
+                          .arg("-stackmap")
+                          .arg(path.to_str().unwrap())
+                          .output()
+                          .expect("failed to run llvm-readelf command");
+        assert!(out.status.success());
+        let stdout = String::from_utf8(out.stdout).unwrap();
+
+        let mut funcs = Vec::new();
+        let mut stkmaps = Vec::new();
+        for line in stdout.lines() {
+            if line.starts_with("  Function address:") {
+                let elems = line.split(",");
+                let mut addr = None;
+                let mut stack_size = None;
+                for e in elems {
+                    let (key, val) = parse_key_val(e);
+                    match key {
+                        "Function address" => addr = Some(val.parse::<u64>().unwrap()),
+                        "stack size" => stack_size = Some(val.parse::<u64>().unwrap()),
+                        _ => (),
+                    }
+                }
+                funcs.push(SMFunc{addr: addr.unwrap(), stack_size: stack_size.unwrap()});
+            } else if line.starts_with("  Record ID:") {
+                let elems = line.split(",");
+                let mut id = None;
+                let mut offset = None;
+                for e in elems {
+                    let (key, val) = parse_key_val(e);
+                    match key {
+                        "Record ID" => id = Some(val.parse::<u64>().unwrap()),
+                        "instruction offset" => offset = Some(val.parse::<u32>().unwrap()),
+                        _ => (),
+                    }
+                }
+                stkmaps.push(SMRec{id: id.unwrap(), offset: offset.unwrap()});
+            }
+        }
+        (funcs, stkmaps)
+    }
+
+    fn check_expected_stackmaps(path: PathBuf) {
+        build_test_inputs(&path);
+        let (expect_funcs, expect_stkmaps) = get_expected(&path);
+        let p = StackMapParser::new(&path).unwrap();
+
+        assert_eq!(expect_funcs.len(), p.num_funcs() as usize);
+        assert_eq!(expect_stkmaps.len(), p.num_stackmaps() as usize);
+        for (got, expect) in p.iter_functions().zip(expect_funcs) {
+            assert_eq!(got.unwrap(), expect);
+        }
+
+        for (got, expect) in p.iter_stackmaps().zip(expect_stkmaps) {
+            assert_eq!(got.unwrap(), expect);
+        }
+    }
+
+    #[test]
+    fn test_hello_world1() {
+        check_expected_stackmaps(test_bin_path("hello_world", "hello_world1"));
+    }
+
+    #[test]
+    fn test_hello_world2() {
+        check_expected_stackmaps(test_bin_path("hello_world", "hello_world2"));
+    }
+
+    #[test]
+    fn test_fannkuch_redux() {
+        check_expected_stackmaps(test_bin_path("fannkuch_redux", "fannkuch_redux"));
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,80 @@
+// Copyright (c) 2018 King's College London
+// Created by the Software Development Team <http://soft-dev.org/>
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any
+// person obtaining a copy of this software, associated documentation and/or
+// data (collectively the "Software"), free of charge and under any and all
+// copyright rights in the Software, and any and all patent rights owned or
+// freely licensable by each licensor hereunder covering either (i) the
+// unmodified Software as contributed to or provided by such licensor, or (ii)
+// the Larger Works (as defined below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
+// if one is included with the Software (each a "Larger Work" to which the Software
+// is contributed by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create
+// derivative works of, display, perform, and distribute the Software and make,
+// use, sell, offer for sale, import, export, have made, and have sold the
+// Software and the Larger Work(s), and to sublicense the foregoing rights on
+// either these or other terms.
+//
+// This license is subject to the following condition: The above copyright
+// notice and either this complete permission notice or at a minimum a reference
+// to the UPL must be included in all copies or substantial portions of the
+// Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use std::io::{self, Cursor, Seek, SeekFrom};
+use {SMParserResult, SMParserError};
+use elf;
+
+const STACKMAP_SECTION_NAME: &str = ".llvm_stackmaps";
+
+pub (crate) fn cursor_from_elf(elf_file: &elf::File, start_pos: u64)
+                               -> SMParserResult<Cursor<&Vec<u8>>> {
+    let sec_res = elf_file.get_section(STACKMAP_SECTION_NAME);
+
+    if let Some(sec) = sec_res {
+        println!("sec addr: {:x}", sec.shdr.offset);
+        let mut cursor = Cursor::new(&sec.data);
+        cursor.seek(SeekFrom::Start(start_pos))?;
+        Ok(cursor)
+    } else {
+        Err(SMParserError::Other(String::from("Can't find stackmap section in binary")))
+    }
+}
+
+/// Skip the cursor forward the specified number of bytes.
+pub (crate) fn cursor_skip(cursor: &mut Cursor<&Vec<u8>>, bytes: i64) -> io::Result<u64> {
+    cursor.seek(SeekFrom::Current(bytes))
+}
+
+/// Align the cursor to the next 8-byte boundary.
+pub (crate) fn cursor_align8(cursor: &mut Cursor<&Vec<u8>>) -> io::Result<u64> {
+    let pad = (8 - (cursor.position() % 8)) % 8;
+    cursor_skip(cursor, pad as i64)
+}
+
+/// A macro to assist in early returns of `Some<Err>` in `Iterator::next()` implementations.
+macro_rules! itry {
+    ($x:expr) => {
+        {
+            let res = $x;
+            match res {
+                Ok(v) => v,
+                Err(e) => return Some(Err(SMParserError::from(e))),
+            }
+        }
+    };
+}

--- a/test_inputs/GNUmakefile
+++ b/test_inputs/GNUmakefile
@@ -1,0 +1,19 @@
+TARGET_DIR = $(shell readlink -f $(shell pwd)/../target/test_inputs)
+BINS =	${TARGET_DIR}/hello_world/hello_world1 \
+	${TARGET_DIR}/hello_world/hello_world2 \
+	${TARGET_DIR}/fannkuch_redux/fannkuch_redux
+
+all: ${BINS}
+
+.SUFFIXES:
+.SUFFIXES: .ll .s
+
+${TARGET_DIR}/%.s: %.ll
+	mkdir -p `dirname $@`
+	llc-6.0 -relocation-model=pic -o $@ $<
+
+${TARGET_DIR}/%: ${TARGET_DIR}/%.s
+	clang-6.0 ${CFLAGS} -o $@ $< ${LDFLAGS}
+
+clean:
+	for i in ${BINS}; do rm -f $$i $$i.s; done

--- a/test_inputs/README.md
+++ b/test_inputs/README.md
@@ -1,0 +1,41 @@
+# Test Inputs
+
+This directory contains a collection of LLVM bytecode programs which are used
+as test inputs.
+
+## Making a New Test Input
+
+Start with a C program as a basis. You can use any C file, but you probably
+don't want anything too large.
+
+Put your C program in a subdirectory. Suppose we start with
+`myinput/myinput.c`. First get a '.bc' bitcode file:
+
+```
+$ clang -emit-llvm -c myinput.c
+```
+
+Next disassemble the bitcode file into a human readable '.ll' file:
+
+```
+$ llvm-dis myinput.bc
+```
+
+Now edit the resulting `.ll` file and add stackmaps and add the signature of
+the stackmap intrinsic:
+
+```
+declare void @llvm.experimental.stackmap(i64, i32, ...)
+```
+
+And also add some calls to the stackmap intrinsic, e.g.:
+
+```
+call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1234, i32 0)
+```
+
+Then add your new test to `BINS` in the `GNUmakefile` in this directory. Running
+`make` will then generate a binary from your `.ll` file.
+
+The `GNUmakefile` outputs binaries to the Rust `target` directory in the crate
+root.

--- a/test_inputs/fannkuch_redux/fannkuch_redux.c
+++ b/test_inputs/fannkuch_redux/fannkuch_redux.c
@@ -1,0 +1,138 @@
+/*
+ * https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/fannkuchredux-gcc-3.html
+ * fetched 2018-06-22
+ *
+ * The only mofifications are the removal on 'inline' on the rotate() function
+ * to make it build with clang, and the addition of the license in the
+ * following comment.
+ */
+
+/*
+ * Copyright © 2004-2008 Brent Fulgham, 2005-2018 Isaac Gouy
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name "The Computer Language Benchmarks Game" nor the name "The
+ *    Benchmarks Game" nor the name "The Computer Language Shootout Benchmarks"
+ *    nor the names of its contributors may be used to endorse or promote
+ *    products derived from this software without specific prior written
+ *    permission. 
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+/* The Computer Language Benchmarks Game
+ * https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
+ *
+ * contributed by Ledrug Katz
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+/* this depends highly on the platform.  It might be faster to use
+   char type on 32-bit systems; it might be faster to use unsigned. */
+
+typedef int elem;
+
+elem s[16], t[16];
+
+int maxflips = 0;
+int max_n;
+int odd = 0;
+int checksum = 0;
+
+int flip()
+{
+   register int i;
+   register elem *x, *y, c;
+
+   for (x = t, y = s, i = max_n; i--; )
+      *x++ = *y++;
+   i = 1;
+   do {
+      for (x = t, y = t + t[0]; x < y; )
+         c = *x, *x++ = *y, *y-- = c;
+      i++;
+   } while (t[t[0]]);
+   return i;
+}
+
+void rotate(int n)
+{
+   elem c;
+   register int i;
+   c = s[0];
+   for (i = 1; i <= n; i++) s[i-1] = s[i];
+   s[n] = c;
+}
+
+/* Tompkin-Paige iterative perm generation */
+void tk(int n)
+{
+   int i = 0, f;
+   elem c[16] = {0};
+
+   while (i < n) {
+      rotate(i);
+      if (c[i] >= i) {
+         c[i++] = 0;
+         continue;
+      }
+
+      c[i]++;
+      i = 1;
+      odd = ~odd;
+      if (*s) {
+         f = s[s[0]] ? flip() : 1;
+         if (f > maxflips) maxflips = f;
+         checksum += odd ? -f : f;
+      }
+   }
+}
+
+int main(int argc, char **v)
+{
+   int i;
+
+   if (argc < 2) {
+      fprintf(stderr, "usage: %s number\n", v[0]);
+      exit(1);
+   }
+
+   max_n = atoi(v[1]);
+   if (max_n < 3 || max_n > 15) {
+      fprintf(stderr, "range: must be 3 <= n <= 12\n");
+      exit(1);
+   }
+
+   for (i = 0; i < max_n; i++) s[i] = i;
+   tk(max_n);
+
+   printf("%d\nPfannkuchen(%d) = %d\n", checksum, max_n, maxflips);
+
+   return 0;
+}

--- a/test_inputs/fannkuch_redux/fannkuch_redux.ll
+++ b/test_inputs/fannkuch_redux/fannkuch_redux.ll
@@ -1,0 +1,387 @@
+; ModuleID = 'fannkuch_redux.bc'
+source_filename = "fannkuch_redux.c"
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+declare void @llvm.experimental.stackmap(i64, i32, ...)
+
+%struct._IO_FILE = type { i32, i8*, i8*, i8*, i8*, i8*, i8*, i8*, i8*, i8*, i8*, i8*, %struct._IO_marker*, %struct._IO_FILE*, i32, i32, i64, i16, i8, [1 x i8], i8*, i64, i8*, i8*, i8*, i8*, i64, i32, [20 x i8] }
+%struct._IO_marker = type { %struct._IO_marker*, %struct._IO_FILE*, i32 }
+
+@maxflips = global i32 0, align 4
+@odd = global i32 0, align 4
+@checksum = global i32 0, align 4
+@t = common global [16 x i32] zeroinitializer, align 16
+@s = common global [16 x i32] zeroinitializer, align 16
+@max_n = common global i32 0, align 4
+@stderr = external global %struct._IO_FILE*, align 8
+@.str = private unnamed_addr constant [18 x i8] c"usage: %s number\0A\00", align 1
+@.str.1 = private unnamed_addr constant [29 x i8] c"range: must be 3 <= n <= 12\0A\00", align 1
+@.str.2 = private unnamed_addr constant [25 x i8] c"%d\0APfannkuchen(%d) = %d\0A\00", align 1
+
+; Function Attrs: noinline nounwind optnone uwtable
+define i32 @flip() #0 {
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 0, i32 8)
+  %1 = alloca i32, align 4
+  %2 = alloca i32*, align 8
+  %3 = alloca i32*, align 8
+  %4 = alloca i32, align 4
+  store i32* getelementptr inbounds ([16 x i32], [16 x i32]* @t, i32 0, i32 0), i32** %2, align 8
+  store i32* getelementptr inbounds ([16 x i32], [16 x i32]* @s, i32 0, i32 0), i32** %3, align 8
+  %5 = load i32, i32* @max_n, align 4
+  store i32 %5, i32* %1, align 4
+  br label %6
+
+; <label>:6:                                      ; preds = %10, %0
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 8)
+  %7 = load i32, i32* %1, align 4
+  %8 = add nsw i32 %7, -1
+  store i32 %8, i32* %1, align 4
+  %9 = icmp ne i32 %7, 0
+  br i1 %9, label %10, label %16
+
+; <label>:10:                                     ; preds = %6
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 2, i32 8)
+  %11 = load i32*, i32** %3, align 8
+  %12 = getelementptr inbounds i32, i32* %11, i32 1
+  store i32* %12, i32** %3, align 8
+  %13 = load i32, i32* %11, align 4
+  %14 = load i32*, i32** %2, align 8
+  %15 = getelementptr inbounds i32, i32* %14, i32 1
+  store i32* %15, i32** %2, align 8
+  store i32 %13, i32* %14, align 4
+  br label %6
+
+; <label>:16:                                     ; preds = %6
+  store i32 1, i32* %1, align 4
+  br label %17
+
+; <label>:17:                                     ; preds = %38, %16
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 3, i32 8)
+  store i32* getelementptr inbounds ([16 x i32], [16 x i32]* @t, i32 0, i32 0), i32** %2, align 8
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 4, i32 8)
+  %18 = load i32, i32* getelementptr inbounds ([16 x i32], [16 x i32]* @t, i64 0, i64 0), align 16
+  %19 = sext i32 %18 to i64
+  %20 = getelementptr inbounds i32, i32* getelementptr inbounds ([16 x i32], [16 x i32]* @t, i32 0, i32 0), i64 %19
+  store i32* %20, i32** %3, align 8
+  br label %21
+
+; <label>:21:                                     ; preds = %25, %17
+  %22 = load i32*, i32** %2, align 8
+  %23 = load i32*, i32** %3, align 8
+  %24 = icmp ult i32* %22, %23
+  br i1 %24, label %25, label %35
+
+; <label>:25:                                     ; preds = %21
+  %26 = load i32*, i32** %2, align 8
+  %27 = load i32, i32* %26, align 4
+  store i32 %27, i32* %4, align 4
+  %28 = load i32*, i32** %3, align 8
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 6, i32 8)
+  %29 = load i32, i32* %28, align 4
+  %30 = load i32*, i32** %2, align 8
+  %31 = getelementptr inbounds i32, i32* %30, i32 1
+  store i32* %31, i32** %2, align 8
+  store i32 %29, i32* %30, align 4
+  %32 = load i32, i32* %4, align 4
+  %33 = load i32*, i32** %3, align 8
+  %34 = getelementptr inbounds i32, i32* %33, i32 -1
+  store i32* %34, i32** %3, align 8
+  store i32 %32, i32* %33, align 4
+  br label %21
+
+; <label>:35:                                     ; preds = %21
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 7, i32 8)
+  %36 = load i32, i32* %1, align 4
+  %37 = add nsw i32 %36, 1
+  store i32 %37, i32* %1, align 4
+  br label %38
+
+; <label>:38:                                     ; preds = %35
+  %39 = load i32, i32* getelementptr inbounds ([16 x i32], [16 x i32]* @t, i64 0, i64 0), align 16
+  %40 = sext i32 %39 to i64
+  %41 = getelementptr inbounds [16 x i32], [16 x i32]* @t, i64 0, i64 %40
+  %42 = load i32, i32* %41, align 4
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 8, i32 8)
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %17, label %44
+
+; <label>:44:                                     ; preds = %38
+  %45 = load i32, i32* %1, align 4
+  ret i32 %45
+}
+
+; Function Attrs: noinline nounwind optnone uwtable
+define void @rotate(i32) #0 {
+  %2 = alloca i32, align 4
+  %3 = alloca i32, align 4
+  %4 = alloca i32, align 4
+  store i32 %0, i32* %2, align 4
+  %5 = load i32, i32* getelementptr inbounds ([16 x i32], [16 x i32]* @s, i64 0, i64 0), align 16
+  store i32 %5, i32* %3, align 4
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 9, i32 8)
+  store i32 1, i32* %4, align 4
+  br label %6
+
+; <label>:6:                                      ; preds = %19, %1
+  %7 = load i32, i32* %4, align 4
+  %8 = load i32, i32* %2, align 4
+  %9 = icmp sle i32 %7, %8
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 10, i32 5)
+  br i1 %9, label %10, label %22
+
+; <label>:10:                                     ; preds = %6
+  %11 = load i32, i32* %4, align 4
+  %12 = sext i32 %11 to i64
+  %13 = getelementptr inbounds [16 x i32], [16 x i32]* @s, i64 0, i64 %12
+  %14 = load i32, i32* %13, align 4
+  %15 = load i32, i32* %4, align 4
+  %16 = sub nsw i32 %15, 1
+  %17 = sext i32 %16 to i64
+  %18 = getelementptr inbounds [16 x i32], [16 x i32]* @s, i64 0, i64 %17
+  store i32 %14, i32* %18, align 4
+  br label %19
+
+; <label>:19:                                     ; preds = %10
+  %20 = load i32, i32* %4, align 4
+  %21 = add nsw i32 %20, 1
+  store i32 %21, i32* %4, align 4
+  br label %6
+
+; <label>:22:                                     ; preds = %6
+  %23 = load i32, i32* %3, align 4
+  %24 = load i32, i32* %2, align 4
+  %25 = sext i32 %24 to i64
+  %26 = getelementptr inbounds [16 x i32], [16 x i32]* @s, i64 0, i64 %25
+  store i32 %23, i32* %26, align 4
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 11, i32 8)
+  ret void
+}
+
+; Function Attrs: noinline nounwind optnone uwtable
+define void @tk(i32) #0 {
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 12, i32 8)
+  %2 = alloca i32, align 4
+  %3 = alloca i32, align 4
+  %4 = alloca i32, align 4
+  %5 = alloca [16 x i32], align 16
+  store i32 %0, i32* %2, align 4
+  store i32 0, i32* %3, align 4
+  %6 = bitcast [16 x i32]* %5 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %6, i8 0, i64 64, i32 16, i1 false)
+  br label %7
+
+; <label>:7:                                      ; preds = %62, %19, %1
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 13, i32 8)
+  %8 = load i32, i32* %3, align 4
+  %9 = load i32, i32* %2, align 4
+  %10 = icmp slt i32 %8, %9
+  br i1 %10, label %11, label %63
+
+; <label>:11:                                     ; preds = %7
+  %12 = load i32, i32* %3, align 4
+  call void @rotate(i32 %12)
+  %13 = load i32, i32* %3, align 4
+  %14 = sext i32 %13 to i64
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 14, i32 8)
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 15, i32 8)
+  %15 = getelementptr inbounds [16 x i32], [16 x i32]* %5, i64 0, i64 %14
+  %16 = load i32, i32* %15, align 4
+  %17 = load i32, i32* %3, align 4
+  %18 = icmp sge i32 %16, %17
+  br i1 %18, label %19, label %24
+
+; <label>:19:                                     ; preds = %11
+  %20 = load i32, i32* %3, align 4
+  %21 = add nsw i32 %20, 1
+  store i32 %21, i32* %3, align 4
+  %22 = sext i32 %20 to i64
+  %23 = getelementptr inbounds [16 x i32], [16 x i32]* %5, i64 0, i64 %22
+  store i32 0, i32* %23, align 4
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 16, i32 8)
+  br label %7
+
+; <label>:24:                                     ; preds = %11
+  %25 = load i32, i32* %3, align 4
+  %26 = sext i32 %25 to i64
+  %27 = getelementptr inbounds [16 x i32], [16 x i32]* %5, i64 0, i64 %26
+  %28 = load i32, i32* %27, align 4
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 17, i32 8)
+  %29 = add nsw i32 %28, 1
+  store i32 %29, i32* %27, align 4
+  store i32 1, i32* %3, align 4
+  %30 = load i32, i32* @odd, align 4
+  %31 = xor i32 %30, -1
+  store i32 %31, i32* @odd, align 4
+  %32 = load i32, i32* getelementptr inbounds ([16 x i32], [16 x i32]* @s, i32 0, i32 0), align 16
+  %33 = icmp ne i32 %32, 0
+  br i1 %33, label %34, label %62
+
+; <label>:34:                                     ; preds = %24
+  %35 = load i32, i32* getelementptr inbounds ([16 x i32], [16 x i32]* @s, i64 0, i64 0), align 16
+  %36 = sext i32 %35 to i64
+  %37 = getelementptr inbounds [16 x i32], [16 x i32]* @s, i64 0, i64 %36
+  %38 = load i32, i32* %37, align 4
+  %39 = icmp ne i32 %38, 0
+  br i1 %39, label %40, label %42
+
+; <label>:40:                                     ; preds = %34
+  %41 = call i32 @flip()
+  br label %43
+
+; <label>:42:                                     ; preds = %34
+  br label %43
+
+; <label>:43:                                     ; preds = %42, %40
+  %44 = phi i32 [ %41, %40 ], [ 1, %42 ]
+  store i32 %44, i32* %4, align 4
+  %45 = load i32, i32* %4, align 4
+  %46 = load i32, i32* @maxflips, align 4
+  %47 = icmp sgt i32 %45, %46
+  br i1 %47, label %48, label %50
+
+; <label>:48:                                     ; preds = %43
+  %49 = load i32, i32* %4, align 4
+  store i32 %49, i32* @maxflips, align 4
+  br label %50
+
+; <label>:50:                                     ; preds = %48, %43
+  %51 = load i32, i32* @odd, align 4
+  %52 = icmp ne i32 %51, 0
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 0, i32 8)
+  br i1 %52, label %53, label %56
+
+; <label>:53:                                     ; preds = %50
+  %54 = load i32, i32* %4, align 4
+  %55 = sub nsw i32 0, %54
+  br label %58
+
+; <label>:56:                                     ; preds = %50
+  %57 = load i32, i32* %4, align 4
+  br label %58
+
+; <label>:58:                                     ; preds = %56, %53
+  %59 = phi i32 [ %55, %53 ], [ %57, %56 ]
+  %60 = load i32, i32* @checksum, align 4
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 0, i32 8)
+  %61 = add nsw i32 %60, %59
+  store i32 %61, i32* @checksum, align 4
+  br label %62
+
+; <label>:62:                                     ; preds = %58, %24
+  br label %7
+
+; <label>:63:                                     ; preds = %7
+  ret void
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i32, i1) #1
+
+; Function Attrs: noinline nounwind optnone uwtable
+define i32 @main(i32, i8**) #0 {
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 0, i32 8)
+  %3 = alloca i32, align 4
+  %4 = alloca i32, align 4
+  %5 = alloca i8**, align 8
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 0, i32 8)
+  %6 = alloca i32, align 4
+  store i32 0, i32* %3, align 4
+  store i32 %0, i32* %4, align 4
+  store i8** %1, i8*** %5, align 8
+  %7 = load i32, i32* %4, align 4
+  %8 = icmp slt i32 %7, 2
+  br i1 %8, label %9, label %15
+
+; <label>:9:                                      ; preds = %2
+  %10 = load %struct._IO_FILE*, %struct._IO_FILE** @stderr, align 8
+  %11 = load i8**, i8*** %5, align 8
+  %12 = getelementptr inbounds i8*, i8** %11, i64 0
+  %13 = load i8*, i8** %12, align 8
+  %14 = call i32 (%struct._IO_FILE*, i8*, ...) @fprintf(%struct._IO_FILE* %10, i8* getelementptr inbounds ([18 x i8], [18 x i8]* @.str, i32 0, i32 0), i8* %13)
+  call void @exit(i32 1) #5
+  unreachable
+
+; <label>:15:                                     ; preds = %2
+  %16 = load i8**, i8*** %5, align 8
+  %17 = getelementptr inbounds i8*, i8** %16, i64 1
+  %18 = load i8*, i8** %17, align 8
+  %19 = call i32 @atoi(i8* %18) #6
+  store i32 %19, i32* @max_n, align 4
+  %20 = load i32, i32* @max_n, align 4
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 0, i32 8)
+  %21 = icmp slt i32 %20, 3
+  br i1 %21, label %25, label %22
+
+; <label>:22:                                     ; preds = %15
+  %23 = load i32, i32* @max_n, align 4
+  %24 = icmp sgt i32 %23, 15
+  br i1 %24, label %25, label %28
+
+; <label>:25:                                     ; preds = %22, %15
+  %26 = load %struct._IO_FILE*, %struct._IO_FILE** @stderr, align 8
+  %27 = call i32 (%struct._IO_FILE*, i8*, ...) @fprintf(%struct._IO_FILE* %26, i8* getelementptr inbounds ([29 x i8], [29 x i8]* @.str.1, i32 0, i32 0))
+  call void @exit(i32 1) #5
+  unreachable
+
+; <label>:28:                                     ; preds = %22
+  store i32 0, i32* %6, align 4
+  br label %29
+
+; <label>:29:                                     ; preds = %38, %28
+  %30 = load i32, i32* %6, align 4
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 0, i32 8)
+  %31 = load i32, i32* @max_n, align 4
+  %32 = icmp slt i32 %30, %31
+  br i1 %32, label %33, label %41
+
+; <label>:33:                                     ; preds = %29
+  %34 = load i32, i32* %6, align 4
+  %35 = load i32, i32* %6, align 4
+  %36 = sext i32 %35 to i64
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 0, i32 8)
+  %37 = getelementptr inbounds [16 x i32], [16 x i32]* @s, i64 0, i64 %36
+  store i32 %34, i32* %37, align 4
+  br label %38
+
+; <label>:38:                                     ; preds = %33
+  %39 = load i32, i32* %6, align 4
+  %40 = add nsw i32 %39, 1
+  store i32 %40, i32* %6, align 4
+  br label %29
+
+; <label>:41:                                     ; preds = %29
+  %42 = load i32, i32* @max_n, align 4
+  call void @tk(i32 %42)
+  %43 = load i32, i32* @checksum, align 4
+  %44 = load i32, i32* @max_n, align 4
+  %45 = load i32, i32* @maxflips, align 4
+  %46 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([25 x i8], [25 x i8]* @.str.2, i32 0, i32 0), i32 %43, i32 %44, i32 %45)
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 0, i32 8)
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 0, i32 8)
+  ret i32 0
+}
+
+declare i32 @fprintf(%struct._IO_FILE*, i8*, ...) #2
+
+; Function Attrs: noreturn nounwind
+declare void @exit(i32) #3
+
+; Function Attrs: nounwind readonly
+declare i32 @atoi(i8*) #4
+
+declare i32 @printf(i8*, ...) #2
+
+attributes #0 = { noinline nounwind optnone uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { argmemonly nounwind }
+attributes #2 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { noreturn nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #4 = { nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #5 = { noreturn nounwind }
+attributes #6 = { nounwind readonly }
+
+!llvm.module.flags = !{!0}
+!llvm.ident = !{!1}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{!"clang version 6.0.1-svn333623-1~exp1~20180604223356.84 (branches/release_60)"}

--- a/test_inputs/hello_world/hello_world.c
+++ b/test_inputs/hello_world/hello_world.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int
+main(int argc, char **argv)
+{
+    printf("hello world!\n:");
+    return (EXIT_SUCCESS);
+}

--- a/test_inputs/hello_world/hello_world1.ll
+++ b/test_inputs/hello_world/hello_world1.ll
@@ -1,0 +1,32 @@
+; Derived from hello_world.c
+; One stackmap call added to the start of main().
+
+; ModuleID = 'hello_world.bc'
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+declare void @llvm.experimental.stackmap(i64, i32, ...)
+
+@.str = private unnamed_addr constant [15 x i8] c"hello world!\0A:\00", align 1
+
+; Function Attrs: nounwind uwtable
+define i32 @main(i32 %argc, i8** %argv) #0 {
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1234, i32 0)
+  %1 = alloca i32, align 4
+  %2 = alloca i32, align 4
+  %3 = alloca i8**, align 8
+  store i32 0, i32* %1, align 4
+  store i32 %argc, i32* %2, align 4
+  store i8** %argv, i8*** %3, align 8
+  %4 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([15 x i8], [15 x i8]* @.str, i32 0, i32 0))
+  ret i32 0
+}
+
+declare i32 @printf(i8*, ...) #1
+
+attributes #0 = { nounwind uwtable "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+fxsr,+mmx,+sse,+sse2" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+fxsr,+mmx,+sse,+sse2" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!llvm.ident = !{!0}
+
+!0 = !{!"clang version 3.8.1-24 (tags/RELEASE_381/final)"}

--- a/test_inputs/hello_world/hello_world2.ll
+++ b/test_inputs/hello_world/hello_world2.ll
@@ -1,0 +1,34 @@
+; Derived from hello_world.c
+; One stackmap call added to the start of main().
+
+; ModuleID = 'hello_world.bc'
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+declare void @llvm.experimental.stackmap(i64, i32, ...)
+
+@.str = private unnamed_addr constant [15 x i8] c"hello world!\0A:\00", align 1
+
+; Function Attrs: nounwind uwtable
+define i32 @main(i32 %argc, i8** %argv) #0 {
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1234, i32 0)
+  %1 = alloca i32, align 4
+  %2 = alloca i32, align 4
+  %3 = alloca i8**, align 8
+  store i32 0, i32* %1, align 4
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 8888, i32 4)
+  store i32 %argc, i32* %2, align 4
+  store i8** %argv, i8*** %3, align 8
+  %4 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([15 x i8], [15 x i8]* @.str, i32 0, i32 0))
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 8889, i32 10)
+  ret i32 0
+}
+
+declare i32 @printf(i8*, ...) #1
+
+attributes #0 = { nounwind uwtable "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+fxsr,+mmx,+sse,+sse2" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+fxsr,+mmx,+sse,+sse2" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!llvm.ident = !{!0}
+
+!0 = !{!"clang version 3.8.1-24 (tags/RELEASE_381/final)"}


### PR DESCRIPTION
A simple stackmap parser.

Currently only the information that we will obviously need for yorickrt
is being exposed, but we can extract additional info in a later change
if required.

Notes:
 * Although not strictly necessary, I've included the C sources from which the `.ll` files were (manually) generated. I did this on the basis that it makes it easier to regenerate or add new tests.
 * The test suite currently requires LLVM-6.0 with binaries suffixed
`-6.0`. LLVM bytecodes containing stackmap call are compiled as test
inputs, then the results of `llvm-readelf -stackmap` are compared to the
results of the library.
 * Take a look at this before reviewing: https://llvm.org/docs/StackMaps.html#stack-map-format

Comments?