### PR TITLE
Bump LLVM version and update travis to use patched readobj

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ addons:
 before_script:
     - wget "https://github.com/jacob-hughes/llvm-readobj-bin/blob/master/archive/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux.tar.gz?raw=true" -O /tmp/llvm-readobj-v3.tar.gz
     - tar -xzvf /tmp/llvm-readobj-v3.tar.gz
-    - export PATH="$PATH:$HOME/.cargo/bin:$PWD/llvm-readbj-v3"
+    - export PATH="$PATH:$HOME/.cargo/bin:$PWD/llvm-readobj-v3"
 
 script:
     - cargo build --examples

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,9 @@ addons:
       - libfuzzer-8-dev
 
 before_script:
-    - wget "https://github.com/jacob-hughes/llvm-readobj-bin/blob/master/archive/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux.tar.gz?raw=true" -O /tmp/llvm-readobj.tar.gz
-    - tar -xzvf /tmp/llvm-readobj.tar.gz
-    - export PATH="$PATH:$HOME/.cargo/bin:$PWD/llvm-readbj"
+    - wget "https://github.com/jacob-hughes/llvm-readobj-bin/blob/master/archive/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux.tar.gz?raw=true" -O /tmp/llvm-readobj-v3.tar.gz
+    - tar -xzvf /tmp/llvm-readobj-v3.tar.gz
+    - export PATH="$PATH:$HOME/.cargo/bin:$PWD/llvm-readbj-v3"
 
 script:
     - cargo build --examples
@@ -37,4 +37,4 @@ script:
     - cargo test
 
 env:
-    - LLVM_READOBJ_PATH=llvm-readobj
+    - LLVM_READOBJ_PATH=llvm-readobj-v3

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ addons:
 before_script:
     - wget "https://github.com/jacob-hughes/llvm-readobj-bin/blob/master/archive/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux.tar.gz?raw=true" -O /tmp/llvm-readobj-v3.tar.gz
     - tar -xzvf /tmp/llvm-readobj-v3.tar.gz
-    - export PATH="$PATH:$HOME/.cargo/bin:$PWD/llvm-readobj-v3"
+    - export PATH="$PATH:$HOME/.cargo/bin:$PWD/llvm-readobj-v3-stackmap-x86-64-gnu-linux"
 
 script:
     - cargo build --examples
@@ -37,4 +37,4 @@ script:
     - cargo test
 
 env:
-    - LLVM_READOBJ_PATH=llvm-readobj-v3
+    - LLVM_READOBJ_PATH=llvm-readobj-v3-stackmap-x86-64-gnu-linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,25 +5,25 @@ cache: cargo
 addons:
   apt:
     sources:
-      - llvm-toolchain-trusty-6.0
+      - llvm-toolchain-trusty-8.0
       - ubuntu-toolchain-r-test
     packages:
-      - clang-6.0
-      - clang-tools-6.0
-      - clang-6.0-doc
-      - libclang-common-6.0-dev
-      - libclang-6.0-dev
-      - libclang1-6.0
-      - libllvm6.0
-      - llvm-6.0
-      - llvm-6.0-dev
-      - llvm-6.0-doc
-      - llvm-6.0-examples
-      - llvm-6.0-runtime
-      - clang-format-6.0
-      - python-clang-6.0
-      - lld-6.0
-      - libfuzzer-6.0-dev
+      - clang-8.0
+      - clang-tools-8.0
+      - clang-8.0-doc
+      - libclang-common-8.0-dev
+      - libclang-8.0-dev
+      - libclang1-8.0
+      - libllvm8.0
+      - llvm-8.0
+      - llvm-8.0-dev
+      - llvm-8.0-doc
+      - llvm-8.0-examples
+      - llvm-8.0-runtime
+      - clang-format-8.0
+      - python-clang-8.0
+      - lld-8.0
+      - libfuzzer-8.0-dev
 
 before_script:
     - export PATH="$PATH:$HOME/.cargo/bin"

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,6 @@ script:
     - cargo build --examples
     - cargo doc --no-deps
     - cargo test
+
+env:
+    - LLVM_READOBJ_PATH=/tmp/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ addons:
       - libfuzzer-8-dev
 
 before_script:
-    - wget https://github.com/jacob-hughes/llvm-readobj-bin/blob/master/archive/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux.tar.gz -o /tmp/llvm-8-readobj.tar.gz
+    - wget https://github.com/jacob-hughes/llvm-readobj-bin/blob/master/archive/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux.tar.gz?raw=true -o /tmp/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux.tar.gz
     - tar -xzvf /tmp/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux.tar.gz
     - export LLVM_READOBJ_PATH="/tmp/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux"
     - export PATH="$PATH:$HOME/.cargo/bin"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ cache: cargo
 addons:
   apt:
     sources:
-      - llvm-toolchain-8
+      - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-8 main'
+        key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
       - ubuntu-toolchain-r-test
     packages:
       - clang-8

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ addons:
       - libfuzzer-8.0-dev
 
 before_script:
+    - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add - 
+    - echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-8 main" | sudo tee -a /etc/apt/sources.list
+    - sudo apt-get update
     - wget https://github.com/jacob-hughes/llvm-readobj-bin/blob/master/archive/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux.tar.gz -o /tmp/llvm-8-readobj.tar.gz
     - tar -xzvf /tmp/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux.tar.gz
     - export LLVM_READOBJ_PATH="/tmp/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ addons:
       - libfuzzer-8.0-dev
 
 before_script:
+    - wget https://github.com/jacob-hughes/llvm-readobj-bin/blob/master/archive/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux.tar.gz -o /tmp/llvm-8-readobj.tar.gz
+    - tar -xzvf /tmp/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux.tar.gz
+    - export LLVM_READOBJ_PATH="/tmp/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux"
     - export PATH="$PATH:$HOME/.cargo/bin"
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,25 +5,25 @@ cache: cargo
 addons:
   apt:
     sources:
-      - llvm-toolchain-8.0
+      - llvm-toolchain-8
       - ubuntu-toolchain-r-test
     packages:
-      - clang-8.0
-      - clang-tools-8.0
-      - clang-8.0-doc
-      - libclang-common-8.0-dev
-      - libclang-8.0-dev
-      - libclang1-8.0
-      - libllvm8.0
-      - llvm-8.0
-      - llvm-8.0-dev
-      - llvm-8.0-doc
-      - llvm-8.0-examples
-      - llvm-8.0-runtime
-      - clang-format-8.0
-      - python-clang-8.0
-      - lld-8.0
-      - libfuzzer-8.0-dev
+      - clang-8
+      - clang-tools-8
+      - clang-8-doc
+      - libclang-common-8-dev
+      - libclang-8-dev
+      - libclang1-8
+      - libllvm8
+      - llvm-8
+      - llvm-8-dev
+      - llvm-8-doc
+      - llvm-8-examples
+      - llvm-8-runtime
+      - clang-format-8
+      - python-clang-8
+      - lld-8
+      - libfuzzer-8-dev
 
 before_script:
     - wget https://github.com/jacob-hughes/llvm-readobj-bin/blob/master/archive/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux.tar.gz -o /tmp/llvm-8-readobj.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache: cargo
 addons:
   apt:
     sources:
-      - llvm-toolchain-trusty-8.0
+      - llvm-toolchain-8.0
       - ubuntu-toolchain-r-test
     packages:
       - clang-8.0
@@ -26,9 +26,6 @@ addons:
       - libfuzzer-8.0-dev
 
 before_script:
-    - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add - 
-    - echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-8 main" | sudo tee -a /etc/apt/sources.list
-    - sudo apt-get update
     - wget https://github.com/jacob-hughes/llvm-readobj-bin/blob/master/archive/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux.tar.gz -o /tmp/llvm-8-readobj.tar.gz
     - tar -xzvf /tmp/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux.tar.gz
     - export LLVM_READOBJ_PATH="/tmp/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux"

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,7 @@ addons:
 
 before_script:
     - wget "https://github.com/jacob-hughes/llvm-readobj-bin/blob/master/archive/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux.tar.gz?raw=true" -O /tmp/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux.tar.gz
-    - tar -xzvf /tmp/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux.tar.gz
-    - export LLVM_READOBJ_PATH="/tmp/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux"
+    - tar -xzvf /tmp/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux.tar.gz -C /tmp/
     - export PATH="$PATH:$HOME/.cargo/bin"
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ addons:
       - libfuzzer-8-dev
 
 before_script:
-    - wget https://github.com/jacob-hughes/llvm-readobj-bin/blob/master/archive/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux.tar.gz?raw=true -o /tmp/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux.tar.gz
+    - wget "https://github.com/jacob-hughes/llvm-readobj-bin/blob/master/archive/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux.tar.gz?raw=true" -O /tmp/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux.tar.gz
     - tar -xzvf /tmp/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux.tar.gz
     - export LLVM_READOBJ_PATH="/tmp/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux"
     - export PATH="$PATH:$HOME/.cargo/bin"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,9 @@ addons:
       - libfuzzer-8-dev
 
 before_script:
-    - wget "https://github.com/jacob-hughes/llvm-readobj-bin/blob/master/archive/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux.tar.gz?raw=true" -O /tmp/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux.tar.gz
-    - tar -xzvf /tmp/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux.tar.gz -C /tmp/
-    - export PATH="$PATH:$HOME/.cargo/bin"
+    - wget "https://github.com/jacob-hughes/llvm-readobj-bin/blob/master/archive/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux.tar.gz?raw=true" -O /tmp/llvm-readobj.tar.gz
+    - tar -xzvf /tmp/llvm-readobj.tar.gz
+    - export PATH="$PATH:$HOME/.cargo/bin:$PWD/llvm-readbj"
 
 script:
     - cargo build --examples
@@ -37,4 +37,4 @@ script:
     - cargo test
 
 env:
-    - LLVM_READOBJ_PATH=/tmp/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux
+    - LLVM_READOBJ_PATH=llvm-readobj

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,7 @@ addons:
 
 before_script:
     - wget "https://github.com/jacob-hughes/llvm-readobj-bin/blob/master/archive/llvm-8-readobj-v3-stackmap-x86-64-gnu-linux.tar.gz?raw=true" -O /tmp/llvm-readobj-v3.tar.gz
-    - tar -xzvf /tmp/llvm-readobj-v3.tar.gz
-    - export PATH="$PATH:$HOME/.cargo/bin:$PWD/llvm-readobj-v3-stackmap-x86-64-gnu-linux"
+    - tar -xzvf /tmp/llvm-readobj-v3.tar.gz -C /tmp/
 
 script:
     - cargo build --examples
@@ -37,4 +36,4 @@ script:
     - cargo test
 
 env:
-    - LLVM_READOBJ_PATH=llvm-readobj-v3-stackmap-x86-64-gnu-linux
+    - LLVM_READOBJ_PATH=/tmp/llvm-readobj-v3-stackmap-x86-64-gnu-linux

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,10 +341,9 @@ mod tests {
     use std::process::Command;
     use super::{SMFunc, SMRec, StackMapParser};
 
-    const LLVM_READELF: &str = "llvm-readelf-6.0";
-
     #[cfg(target_os="linux")]
     const MAKE: &str = "make";
+    const LLVM_READOBJ_PATH: &str = "LLVM_READOBJ_PATH";
 
     // Invokes GNU make to build a test input.
     fn build_test_inputs(path: &PathBuf) {
@@ -388,7 +387,11 @@ mod tests {
 
     // Parse the output of llvm-readelf to get expected outcomes.
     fn get_expected(path: &Path) -> (Vec<SMFunc>, Vec<SMRec>) {
-        let out = Command::new(LLVM_READELF)
+        let readelf = match env::var(LLVM_READOBJ_PATH) {
+            Ok(val) => val,
+            Err(e) => panic!("No {} environment variable provided", LLVM_READOBJ_PATH),
+        };
+        let out = Command::new(readelf)
                           .arg("-stackmap")
                           .arg(path.to_str().unwrap())
                           .output()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,6 +396,8 @@ mod tests {
                           .arg(path.to_str().unwrap())
                           .output()
                           .expect("failed to run llvm-readelf command");
+        dbg!{&out.stdout};
+        dbg!{&out.stderr};
         assert!(out.status.success());
         let stdout = String::from_utf8(out.stdout).unwrap();
 

--- a/test_inputs/GNUmakefile
+++ b/test_inputs/GNUmakefile
@@ -10,10 +10,10 @@ all: ${BINS}
 
 ${TARGET_DIR}/%.s: %.ll
 	mkdir -p `dirname $@`
-	llc-6.0 -relocation-model=pic -o $@ $<
+	llc-8 -relocation-model=pic -o $@ $<
 
 ${TARGET_DIR}/%: ${TARGET_DIR}/%.s
-	clang-6.0 ${CFLAGS} -o $@ $< ${LDFLAGS}
+	clang-8 ${CFLAGS} -o $@ $< ${LDFLAGS}
 
 clean:
 	for i in ${BINS}; do rm -f $$i $$i.s; done


### PR DESCRIPTION
When running the tests, the user will now have to supply the path of the `llvm-readobj` binary using the `LLVM_READOBJ_PATH` environment variable. 

Travis has been updated to download a precompiled version of this patched bin and use this to run the build script.

( I'll be amazed if travis doesn't complain first time round)