### PR TITLE
Parse Stackmap Record Locations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,59 @@ const OFFS_STACK_SIZE_ENTRIES: u64 = 16;
 pub struct SMRec {
     id: u64,            // Stackmap ID.
     offset: u32,        // Stackmap offset from start of containing func.
+    num_locs: u16,
+    locs: Vec<SMLoc>,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct SMLoc {
+    kind: LocKind,
+    size: u16,
+    dwarf_reg: u16,
+    offset: LocOffset,
+}
+
+/// Unfortunately, due to a discrepancy between the llvm stackmap documentation
+/// [0] and the implementation of their own stackmap parser [1], we need this
+/// enum to interpret the integer type differently depending on its `LocKind`.
+/// The offset is interpreted as a u32 *iff* the `LocKind` is a Constant. In all
+/// other cases, this is an i32. There are examples [2] in the LLVM test suite
+/// where the offset value contains an integer which won't fit inside an i32.
+/// For now, we interpret this in the same way that llvm-readobj and its test
+/// suite expects.
+///
+/// [0] https://llvm.org/docs/StackMaps.html#id10
+/// [1] https://github.com/llvm/llvm-project/blob/57b38a8593bd7d63b9db09676087365d8d3d0d8a/llvm/include/llvm/Object/StackMapParser.h#L123
+/// [2] https://github.com/llvm/llvm-project/blob/master/llvm/test/CodeGen/X86/stackmap-large-location-size.ll
+///
+// #XXX: Update this when we get clarification on what the correct behaviour is
+// from the LLVM devs.
+#[derive(Debug, Eq, PartialEq)]
+pub enum LocOffset {
+    I32(i32),
+    U32(u32)
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum LocKind {
+    Register,
+    Direct,
+    Indirect,
+    Constant,
+    ConstIndex
+}
+
+impl LocKind {
+    fn from_hex(val: u8) -> SMParserResult<LocKind>{
+        match val {
+            0x1 => Ok(LocKind::Register),
+            0x2 => Ok(LocKind::Direct),
+            0x3 => Ok(LocKind::Indirect),
+            0x4 => Ok(LocKind::Constant),
+            0x5 => Ok(LocKind::ConstIndex),
+            x => Err(SMParserError::Other(format!("Unknown location kind '{}'", x))),
+        }
+    }
 }
 
 impl SMRec {
@@ -128,9 +181,9 @@ impl<'a> Iterator for SMRecIterator<'a> {
 
         // StkMapRecord[NumRecords] {
         //     uint64: PatchPoint ID
-        let sm_id = itry!(cursor.read_u64::<NativeEndian>());
+        let id = itry!(cursor.read_u64::<NativeEndian>());
         //     uint32: Instruction Offset
-        let sm_offset = itry!(cursor.read_u32::<NativeEndian>());
+        let offset = itry!(cursor.read_u32::<NativeEndian>());
 
         // At this point we have everything we need from this entry, but need to skip the remainder
         // of the (variable-sized) entry to find the start of the next.
@@ -141,11 +194,25 @@ impl<'a> Iterator for SMRecIterator<'a> {
         //     uint16: NumLocations
         let num_locs = itry!(cursor.read_u16::<NativeEndian>());
         //     Location[NumLocations] { ... }
+        let loc_iter = SMLocIterator {
+            elf_file: self.elf_file,
+            cursor: None,
+            start_pos: cursor.position(),
+            num_locs: num_locs
+        };
+
+        let mut locs = Vec::with_capacity(num_locs as usize);
+        for loc in loc_iter {
+            locs.push(loc.expect("malformed location"))
+        }
+
         let skip_locs_sz = u64::from(u32::from(num_locs) * u32::from(SIZE_LOC_ENTRY));
         itry!(cursor_skip(&mut cursor, skip_locs_sz as i64));
+
         //     uint32: Padding (only if required to align to 8 byte)
         //     uint16: Padding
         itry!(cursor_align8(&mut cursor));
+        itry!(cursor_skip(&mut cursor, 2));
 
         //     uint16: NumLiveOuts
         let num_liveouts = itry!(cursor.read_u16::<NativeEndian>());
@@ -158,7 +225,55 @@ impl<'a> Iterator for SMRecIterator<'a> {
         // } -- End of this stackmap record.
 
         self.num_stackmaps -= 1;
-        Some(Ok(SMRec{id: sm_id, offset: sm_offset}))
+        Some(Ok(SMRec { id, offset, num_locs, locs }))
+    }
+}
+
+struct SMLocIterator<'a> {
+    elf_file: &'a elf::File,
+    cursor: Option<Cursor<&'a Vec<u8>>>,
+    start_pos: u64,
+    num_locs: u16
+}
+
+impl<'a> Iterator for SMLocIterator<'a> {
+    type Item = SMParserResult<SMLoc>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.num_locs == 0 {
+            return None;
+        }
+
+        if self.cursor.is_none() {
+            self.cursor = Some(itry!(cursor_from_elf(self.elf_file, self.start_pos)));
+        }
+
+        let cursor = self.cursor.as_mut().unwrap();
+        // Location[NumRecords] {
+        //     uint8: Register | Direct | Indirect | Constant | ConstIndex
+        let kind = itry!(cursor.read_u8());
+        let kind = itry!(LocKind::from_hex(kind));
+        //     uint8: Reserved (expected to be 0)
+        assert_eq!(itry!(cursor.read_u8()), 0);
+        //     uint16: Location Size
+        let size = itry!(cursor.read_u16::<NativeEndian>());
+        //     uint16: Dwarf RegNum
+        let dwarf_reg = itry!(cursor.read_u16::<NativeEndian>());
+        //     uint16: Reserved (expected to be 0)
+        assert_eq!(itry!(cursor.read_u16::<NativeEndian>()), 0);
+        //     int32 | uint32 : Offset
+        let offset = match kind {
+            LocKind::Constant => {
+                let v = itry!(cursor.read_u32::<NativeEndian>());
+                LocOffset::U32(v)
+            },
+            _ => {
+                let v = itry!(cursor.read_i32::<NativeEndian>());
+                LocOffset::I32(v)
+            }
+        };
+        self.num_locs -= 1;
+        Some(Ok(SMLoc { kind, size, dwarf_reg, offset }))
     }
 }
 
@@ -339,7 +454,7 @@ mod tests {
     use std::iter::Iterator;
     use std::path::{Path, PathBuf};
     use std::process::Command;
-    use super::{SMFunc, SMRec, StackMapParser};
+    use super::{SMFunc, SMRec, SMLoc, StackMapParser, LocKind, LocOffset};
 
     #[cfg(target_os="linux")]
     const MAKE: &str = "make";
@@ -390,6 +505,62 @@ mod tests {
         SMFunc { addr, stack_size }
     }
 
+    fn parse_loc(line: &str) -> SMLoc {
+        let elems = line.split(|c| c == ',' || c == ':').collect::<Vec<_>>();
+        // Gives ["#N " LocKind +Data", "0", "size", " 8"]
+
+        let size = elems[3].trim().parse::<u16>().unwrap();
+        let mut loc = elems[1].trim().split_whitespace();
+        let kind = loc.next().unwrap();
+        let rest = loc.collect::<Vec<_>>();
+
+        match kind {
+            "Register" => {
+                // e.g rest: ["R#0"]
+                let kind = LocKind::Register;
+                let dwarf_reg = rest[0].trim_start_matches("R#").parse::<u16>().unwrap();
+                let offset = LocOffset::I32(0);
+                SMLoc { kind, size, dwarf_reg, offset }
+            },
+            "Direct" => {
+                // e.g rest: ["R#0", "+", "-40"]
+                let kind = LocKind::Direct;
+                let dwarf_reg = rest[0].trim_start_matches("R#").parse::<u16>().unwrap();
+                let offset = LocOffset::I32(rest[2].parse::<i32>().unwrap());
+                SMLoc { kind, size, dwarf_reg, offset }
+            },
+            "Indirect" => {
+                // e.g rest: ["[R#0", "+", "-40]"]
+                let kind = LocKind::Indirect;
+                let dwarf_reg = rest[0].trim_start_matches("[R#").parse::<u16>().unwrap();
+                let offset = {
+                    let n = rest[2].trim_end_matches("]").parse::<i32>().unwrap();
+                    LocOffset::I32(n)
+                };
+                SMLoc { kind, size, dwarf_reg, offset }
+            },
+            "Constant" => {
+                let kind = LocKind::Constant;
+                let dwarf_reg = 0;
+                let offset = {
+                    let c = rest[0].parse::<u32>().unwrap();
+                    LocOffset::U32(c)
+                };
+                SMLoc { kind, size, dwarf_reg, offset }
+            },
+            "ConstantIndex" => {
+                let kind = LocKind::ConstIndex;
+                let dwarf_reg = 0;
+                let offset = {
+                    let c = rest[0].trim_start_matches("#").parse::<i32>().unwrap();
+                    LocOffset::I32(c)
+                };
+                SMLoc { kind, size, dwarf_reg, offset }
+            },
+            _ => panic!("Unidentified Location Kind"),
+        }
+    }
+
     // Creates an `SMRec` struct from the iterator over lines of strings given.
     // This will increment the iterator past the lines needed parsing.
     fn parse_record<'a, I>(lines: &mut I) -> SMRec
@@ -404,7 +575,8 @@ mod tests {
         let id = elems[1].trim().parse::<u64>().unwrap();
         let offset = elems[3].trim().parse::<u32>().unwrap();
 
-        // Skip Locs
+        // Location nums line, e.g:
+        //  "4 locations:"
         let num_locs = {
             let line = lines.next().unwrap();
             let n = line.split_whitespace().next().unwrap();
@@ -413,15 +585,13 @@ mod tests {
 
         // Individual location line, e.g:
         //  "#1: Register #R0, size: 8"
-        //  Skip for now
-        for _ in 0..num_locs {
-            lines.next();
-        }
+        // This cast to usize is safe, as num_locs is a u16
+        let locs = lines.take(num_locs as usize).map(|x| parse_loc(x)).collect();
 
         // #TODO Live outs line
         lines.next();
 
-        SMRec { id, offset }
+        SMRec { id, offset, num_locs, locs }
     }
 
     // Parse the output of llvm-readelf to get expected outcomes.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -652,6 +652,11 @@ mod tests {
     }
 
     #[test]
+    fn test_large_stackmap() {
+        check_expected_stackmaps(test_bin_path("large_v3_stackmap", "stackmap"));
+    }
+
+    #[test]
     fn test_hello_world1() {
         check_expected_stackmaps(test_bin_path("hello_world", "hello_world1"));
     }

--- a/test_inputs/GNUmakefile
+++ b/test_inputs/GNUmakefile
@@ -13,7 +13,7 @@ ${TARGET_DIR}/%.s: %.ll
 	llc -relocation-model=pic -o $@ $<
 
 ${TARGET_DIR}/%: ${TARGET_DIR}/%.s
-	clang ${CFLAGS} -o $@ $< ${LDFLAGS}
+	clang -c ${CFLAGS} -o $@ $< ${LDFLAGS}
 
 clean:
 	for i in ${BINS}; do rm -f $$i $$i.s; done

--- a/test_inputs/large_v3_stackmap/stackmap.ll
+++ b/test_inputs/large_v3_stackmap/stackmap.ll
@@ -1,0 +1,575 @@
+; RUN: llc < %s -mtriple=x86_64-apple-darwin -mcpu=corei7 | FileCheck %s
+;
+; Note: Print verbose stackmaps using -debug-only=stackmaps.
+
+; CHECK-LABEL:  .section  __LLVM_STACKMAPS,__llvm_stackmaps
+; CHECK-NEXT:  __LLVM_StackMaps:
+; Header
+; CHECK-NEXT:   .byte 3
+; CHECK-NEXT:   .byte 0
+; CHECK-NEXT:   .short 0
+; Num Functions
+; CHECK-NEXT:   .long 16
+; Num LargeConstants
+; CHECK-NEXT:   .long 3
+; Num Callsites
+; CHECK-NEXT:   .long 20
+
+; Functions and stack size
+; CHECK-NEXT:   .quad _constantargs
+; CHECK-NEXT:   .quad 8
+; CHECK-NEXT:   .quad 1
+; CHECK-NEXT:   .quad _osrinline
+; CHECK-NEXT:   .quad 24
+; CHECK-NEXT:   .quad 1
+; CHECK-NEXT:   .quad _osrcold
+; CHECK-NEXT:   .quad 8
+; CHECK-NEXT:   .quad 1
+; CHECK-NEXT:   .quad _propertyRead
+; CHECK-NEXT:   .quad 8
+; CHECK-NEXT:   .quad 1
+; CHECK-NEXT:   .quad _propertyWrite
+; CHECK-NEXT:   .quad 8
+; CHECK-NEXT:   .quad 1
+; CHECK-NEXT:   .quad _jsVoidCall
+; CHECK-NEXT:   .quad 8
+; CHECK-NEXT:   .quad 1
+; CHECK-NEXT:   .quad _jsIntCall
+; CHECK-NEXT:   .quad 8
+; CHECK-NEXT:   .quad 1
+; CHECK-NEXT:   .quad _spilledValue
+; CHECK-NEXT:   .quad 8
+; CHECK-NEXT:   .quad 1
+; CHECK-NEXT:   .quad _spilledStackMapValue
+; CHECK-NEXT:   .quad 8
+; CHECK-NEXT:   .quad 1
+; CHECK-NEXT:   .quad _spillSubReg
+; CHECK-NEXT:   .quad 56
+; CHECK-NEXT:   .quad 1
+; CHECK-NEXT:   .quad _subRegOffset
+; CHECK-NEXT:   .quad 56
+; CHECK-NEXT:   .quad 1
+; CHECK-NEXT:   .quad _liveConstant
+; CHECK-NEXT:   .quad 8
+; CHECK-NEXT:   .quad 1
+; CHECK-NEXT:   .quad _directFrameIdx
+; CHECK-NEXT:   .quad 56
+; CHECK-NEXT:   .quad 2
+; CHECK-NEXT:   .quad _longid
+; CHECK-NEXT:   .quad 8
+; CHECK-NEXT:   .quad 4
+; CHECK-NEXT:   .quad _clobberScratch
+; CHECK-NEXT:   .quad 56
+; CHECK-NEXT:   .quad 1
+; CHECK-NEXT:   .quad _needsStackRealignment
+; CHECK-NEXT:   .quad -1
+; CHECK-NEXT:   .quad 1
+
+; Large Constants
+; CHECK-NEXT:   .quad   2147483648
+; CHECK-NEXT:   .quad   4294967295
+; CHECK-NEXT:   .quad   4294967296
+
+; Callsites
+; Constant arguments
+;
+; CHECK-NEXT:   .quad   1
+; CHECK-NEXT:   .long   L{{.*}}-_constantargs
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .short  12
+; SmallConstant
+; CHECK-NEXT:   .byte   4
+; CHECK-NEXT:   .byte   0
+; CHECK-NEXT:   .short  8
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .long   -1
+; SmallConstant
+; CHECK-NEXT:   .byte   4
+; CHECK-NEXT:   .byte   0
+; CHECK-NEXT:   .short  8
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .long   -1
+; SmallConstant
+; CHECK-NEXT:   .byte   4
+; CHECK-NEXT:   .byte   0
+; CHECK-NEXT:   .short  8
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .long   65536
+; SmallConstant
+; CHECK-NEXT:   .byte   4
+; CHECK-NEXT:   .byte   0
+; CHECK-NEXT:   .short  8
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .long   2000000000
+; SmallConstant
+; CHECK-NEXT:   .byte   4
+; CHECK-NEXT:   .byte   0
+; CHECK-NEXT:   .short  8
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .long   2147483647
+; SmallConstant
+; CHECK-NEXT:   .byte   4
+; CHECK-NEXT:   .byte   0
+; CHECK-NEXT:   .short  8
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .long   -1
+; SmallConstant
+; CHECK-NEXT:   .byte   4
+; CHECK-NEXT:   .byte   0
+; CHECK-NEXT:   .short  8
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .long   -1
+; SmallConstant
+; CHECK-NEXT:   .byte   4
+; CHECK-NEXT:   .byte   0
+; CHECK-NEXT:   .short  8
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .long   0
+; LargeConstant at index 0
+; CHECK-NEXT:   .byte   5
+; CHECK-NEXT:   .byte   0
+; CHECK-NEXT:   .short  8
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .long   0
+; LargeConstant at index 1
+; CHECK-NEXT:   .byte   5
+; CHECK-NEXT:   .byte   0
+; CHECK-NEXT:   .short  8
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .long   1
+; LargeConstant at index 2
+; CHECK-NEXT:   .byte   5
+; CHECK-NEXT:   .byte   0
+; CHECK-NEXT:   .short  8
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .long   2
+; SmallConstant
+; CHECK-NEXT:   .byte   4
+; CHECK-NEXT:   .byte   0
+; CHECK-NEXT:   .short  8
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .long   -1
+
+define void @constantargs() {
+entry:
+  %0 = inttoptr i64 12345 to i8*
+  tail call void (i64, i32, i8*, i32, ...) @llvm.experimental.patchpoint.void(i64 1, i32 15, i8* %0, i32 0, i16 65535, i16 -1, i32 65536, i32 2000000000, i32 2147483647, i32 -1, i32 4294967295, i32 4294967296, i64 2147483648, i64 4294967295, i64 4294967296, i64 -1)
+  ret void
+}
+
+; Inline OSR Exit
+;
+; CHECK-LABEL:  .long   L{{.*}}-_osrinline
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .short  2
+; CHECK-NEXT:   .byte   1
+; CHECK-NEXT:   .byte   0
+; CHECK-NEXT:   .short  8
+; CHECK-NEXT:   .short  {{[0-9]+}}
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .long   0
+; CHECK-NEXT:   .byte   1
+; CHECK-NEXT:   .byte   0
+; CHECK-NEXT:   .short  8
+; CHECK-NEXT:   .short  {{[0-9]+}}
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .long  0
+define void @osrinline(i64 %a, i64 %b) {
+entry:
+  ; Runtime void->void call.
+  call void inttoptr (i64 -559038737 to void ()*)()
+  ; Followed by inline OSR patchpoint with 12-byte shadow and 2 live vars.
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 3, i32 12, i64 %a, i64 %b)
+  ret void
+}
+
+; Cold OSR Exit
+;
+; 2 live variables in register.
+;
+; CHECK-LABEL:  .long   L{{.*}}-_osrcold
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .short  2
+; CHECK-NEXT:   .byte   1
+; CHECK-NEXT:   .byte   0
+; CHECK-NEXT:   .short  8
+; CHECK-NEXT:   .short  {{[0-9]+}}
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .long   0
+; CHECK-NEXT:   .byte   1
+; CHECK-NEXT:   .byte   0
+; CHECK-NEXT:   .short  8
+; CHECK-NEXT:   .short  {{[0-9]+}}
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .long   0
+define void @osrcold(i64 %a, i64 %b) {
+entry:
+  %test = icmp slt i64 %a, %b
+  br i1 %test, label %ret, label %cold
+cold:
+  ; OSR patchpoint with 12-byte nop-slide and 2 live vars.
+  %thunk = inttoptr i64 -559038737 to i8*
+  call void (i64, i32, i8*, i32, ...) @llvm.experimental.patchpoint.void(i64 4, i32 15, i8* %thunk, i32 0, i64 %a, i64 %b)
+  unreachable
+ret:
+  ret void
+}
+
+; Property Read
+; CHECK-LABEL:  .long   L{{.*}}-_propertyRead
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .short  2
+; CHECK-NEXT:   .byte   1
+; CHECK-NEXT:   .byte   0
+; CHECK-NEXT:   .short  8
+; CHECK-NEXT:   .short  {{[0-9]+}}
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .long   0
+; CHECK-NEXT:   .byte   1
+; CHECK-NEXT:   .byte   0
+; CHECK-NEXT:   .short  8
+; CHECK-NEXT:   .short  {{[0-9]+}}
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .long   0
+define i64 @propertyRead(i64* %obj) {
+entry:
+  %resolveRead = inttoptr i64 -559038737 to i8*
+  %result = call anyregcc i64 (i64, i32, i8*, i32, ...) @llvm.experimental.patchpoint.i64(i64 5, i32 15, i8* %resolveRead, i32 1, i64* %obj)
+  %add = add i64 %result, 3
+  ret i64 %add
+}
+
+; Property Write
+; CHECK-LABEL:  .long   L{{.*}}-_propertyWrite
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .short  2
+; CHECK-NEXT:   .byte   1
+; CHECK-NEXT:   .byte   0
+; CHECK-NEXT:   .short  8
+; CHECK-NEXT:   .short  {{[0-9]+}}
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .long   0
+; CHECK-NEXT:   .byte   1
+; CHECK-NEXT:   .byte   0
+; CHECK-NEXT:   .short  8
+; CHECK-NEXT:   .short  {{[0-9]+}}
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .long   0
+define void @propertyWrite(i64 %dummy1, i64* %obj, i64 %dummy2, i64 %a) {
+entry:
+  %resolveWrite = inttoptr i64 -559038737 to i8*
+  call anyregcc void (i64, i32, i8*, i32, ...) @llvm.experimental.patchpoint.void(i64 6, i32 15, i8* %resolveWrite, i32 2, i64* %obj, i64 %a)
+  ret void
+}
+
+; Void JS Call
+;
+; 2 live variables in registers.
+;
+; CHECK-LABEL:  .long   L{{.*}}-_jsVoidCall
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .short  2
+; CHECK-NEXT:   .byte   1
+; CHECK-NEXT:   .byte   0
+; CHECK-NEXT:   .short  8
+; CHECK-NEXT:   .short  {{[0-9]+}}
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .long   0
+; CHECK-NEXT:   .byte   1
+; CHECK-NEXT:   .byte   0
+; CHECK-NEXT:   .short  8
+; CHECK-NEXT:   .short  {{[0-9]+}}
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .long   0
+define void @jsVoidCall(i64 %dummy1, i64* %obj, i64 %arg, i64 %l1, i64 %l2) {
+entry:
+  %resolveCall = inttoptr i64 -559038737 to i8*
+  call void (i64, i32, i8*, i32, ...) @llvm.experimental.patchpoint.void(i64 7, i32 15, i8* %resolveCall, i32 2, i64* %obj, i64 %arg, i64 %l1, i64 %l2)
+  ret void
+}
+
+; i64 JS Call
+;
+; 2 live variables in registers.
+;
+; CHECK-LABEL:  .long   L{{.*}}-_jsIntCall
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .short  2
+; CHECK-NEXT:   .byte   1
+; CHECK-NEXT:   .byte   0
+; CHECK-NEXT:   .short  8
+; CHECK-NEXT:   .short  {{[0-9]+}}
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .long   0
+; CHECK-NEXT:   .byte   1
+; CHECK-NEXT:   .byte   0
+; CHECK-NEXT:   .short  8
+; CHECK-NEXT:   .short  {{[0-9]+}}
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .long   0
+define i64 @jsIntCall(i64 %dummy1, i64* %obj, i64 %arg, i64 %l1, i64 %l2) {
+entry:
+  %resolveCall = inttoptr i64 -559038737 to i8*
+  %result = call i64 (i64, i32, i8*, i32, ...) @llvm.experimental.patchpoint.i64(i64 8, i32 15, i8* %resolveCall, i32 2, i64* %obj, i64 %arg, i64 %l1, i64 %l2)
+  %add = add i64 %result, 3
+  ret i64 %add
+}
+
+; Spilled stack map values.
+;
+; Verify 17 stack map entries.
+;
+; CHECK-LABEL:  .long L{{.*}}-_spilledValue
+; CHECK-NEXT:   .short 0
+; CHECK-NEXT:   .short 17
+;
+; Check that at least one is a spilled entry from RBP.
+; Location: Indirect RBP + ...
+; CHECK:        .byte 3
+; CHECK-NEXT:   .byte 0
+; CHECK-NEXT:   .short 8
+; CHECK-NEXT:   .short 6
+; CHECK-NEXT:   .short 0
+; CHECK-NEXT:   .long
+define void @spilledValue(i64 %arg0, i64 %arg1, i64 %arg2, i64 %arg3, i64 %arg4, i64 %l0, i64 %l1, i64 %l2, i64 %l3, i64 %l4, i64 %l5, i64 %l6, i64 %l7, i64 %l8, i64 %l9, i64 %l10, i64 %l11, i64 %l12, i64 %l13, i64 %l14, i64 %l15, i64 %l16) {
+entry:
+  call void (i64, i32, i8*, i32, ...) @llvm.experimental.patchpoint.void(i64 11, i32 15, i8* null, i32 5, i64 %arg0, i64 %arg1, i64 %arg2, i64 %arg3, i64 %arg4, i64 %l0, i64 %l1, i64 %l2, i64 %l3, i64 %l4, i64 %l5, i64 %l6, i64 %l7, i64 %l8, i64 %l9, i64 %l10, i64 %l11, i64 %l12, i64 %l13, i64 %l14, i64 %l15, i64 %l16)
+  ret void
+}
+
+; Spilled stack map values.
+;
+; Verify 17 stack map entries.
+;
+; CHECK-LABEL:  .long L{{.*}}-_spilledStackMapValue
+; CHECK-NEXT:   .short 0
+; CHECK-NEXT:   .short 17
+;
+; Check that at least one is a spilled entry from RBP.
+; Location: Indirect RBP + ...
+; CHECK:        .byte 3
+; CHECK-NEXT:   .byte   0
+; CHECK-NEXT:   .short 8
+; CHECK-NEXT:   .short 6
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .long
+define webkit_jscc void @spilledStackMapValue(i64 %l0, i64 %l1, i64 %l2, i64 %l3, i64 %l4, i64 %l5, i64 %l6, i64 %l7, i64 %l8, i64 %l9, i64 %l10, i64 %l11, i64 %l12, i64 %l13, i64 %l14, i64 %l15, i64 %l16) {
+entry:
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 12, i32 15, i64 %l0, i64 %l1, i64 %l2, i64 %l3, i64 %l4, i64 %l5, i64 %l6, i64 %l7, i64 %l8, i64 %l9, i64 %l10, i64 %l11, i64 %l12, i64 %l13, i64 %l14, i64 %l15, i64 %l16)
+  ret void
+}
+
+; Spill a subregister stackmap operand.
+;
+; CHECK-LABEL:  .long L{{.*}}-_spillSubReg
+; CHECK-NEXT:   .short 0
+; 4 locations
+; CHECK-NEXT:   .short 1
+;
+; Check that the subregister operand is a 4-byte spill.
+; Location: Indirect, 4-byte, RBP + ...
+; CHECK:        .byte 3
+; CHECK-NEXT:   .byte 0
+; CHECK-NEXT:   .short 4
+; CHECK-NEXT:   .short 6
+; CHECK-NEXT:   .short 0
+; CHECK-NEXT:   .long
+define void @spillSubReg(i64 %arg) #0 {
+bb:
+  br i1 undef, label %bb1, label %bb2
+
+bb1:
+  unreachable
+
+bb2:
+  %tmp = load i64, i64* inttoptr (i64 140685446136880 to i64*)
+  br i1 undef, label %bb16, label %bb17
+
+bb16:
+  unreachable
+
+bb17:
+  %tmp32 = trunc i64 %tmp to i32
+  br i1 undef, label %bb60, label %bb61
+
+bb60:
+  tail call void asm sideeffect "nop", "~{ax},~{bx},~{cx},~{dx},~{bp},~{si},~{di},~{r8},~{r9},~{r10},~{r11},~{r12},~{r13},~{r14},~{r15}"() nounwind
+  tail call void (i64, i32, ...) @llvm.experimental.stackmap(i64 13, i32 5, i32 %tmp32)
+  unreachable
+
+bb61:
+  unreachable
+}
+
+; Map a single byte subregister. There is no DWARF register number, so
+; we expect the register to be encoded with the proper size and spill offset. We don't know which
+;
+; CHECK-LABEL:  .long L{{.*}}-_subRegOffset
+; CHECK-NEXT:   .short 0
+; 2 locations
+; CHECK-NEXT:   .short 2
+;
+; Check that the subregister operands are 1-byte spills.
+; Location 0: Register, 4-byte, AL
+; CHECK-NEXT:   .byte 1
+; CHECK-NEXT:   .byte   0
+; CHECK-NEXT:   .short 1
+; CHECK-NEXT:   .short 0
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .long 0
+;
+; Location 1: Register, 4-byte, BL
+; CHECK-NEXT:   .byte 1
+; CHECK-NEXT:   .byte 0
+; CHECK-NEXT:   .short 1
+; CHECK-NEXT:   .short 3
+; CHECK-NEXT:   .short 0
+; CHECK-NEXT:   .long 0
+define void @subRegOffset(i16 %arg) {
+  %v = mul i16 %arg, 5
+  %a0 = trunc i16 %v to i8
+  tail call void asm sideeffect "nop", "~{bx}"() nounwind
+  %arghi = lshr i16 %v, 8
+  %a1 = trunc i16 %arghi to i8
+  tail call void asm sideeffect "nop", "~{cx},~{dx},~{bp},~{si},~{di},~{r8},~{r9},~{r10},~{r11},~{r12},~{r13},~{r14},~{r15}"() nounwind
+  tail call void (i64, i32, ...) @llvm.experimental.stackmap(i64 14, i32 5, i8 %a0, i8 %a1)
+  ret void
+}
+
+; Map a constant value.
+;
+; CHECK-LABEL:  .long L{{.*}}-_liveConstant
+; CHECK-NEXT:   .short 0
+; 1 location
+; CHECK-NEXT:   .short 1
+; Loc 0: SmallConstant
+; CHECK-NEXT:   .byte   4
+; CHECK-NEXT:   .byte   0
+; CHECK-NEXT:   .short  8
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .long   33
+
+define void @liveConstant() {
+  tail call void (i64, i32, ...) @llvm.experimental.stackmap(i64 15, i32 5, i32 33)
+  ret void
+}
+
+; Directly map an alloca's address.
+;
+; Callsite 16
+; CHECK-LABEL:  .long L{{.*}}-_directFrameIdx
+; CHECK-NEXT:   .short 0
+; 1 location
+; CHECK-NEXT:   .short	1
+; Loc 0: Direct RBP - ofs
+; CHECK-NEXT:   .byte	2
+; CHECK-NEXT:   .byte	0
+; CHECK-NEXT:   .short	8
+; CHECK-NEXT:   .short	6
+; CHECK-NEXT:   .short	0
+; CHECK-NEXT:   .long
+
+; Callsite 17
+; CHECK-LABEL:  .long	L{{.*}}-_directFrameIdx
+; CHECK-NEXT:   .short	0
+; 2 locations
+; CHECK-NEXT:   .short	2
+; Loc 0: Direct RBP - ofs
+; CHECK-NEXT:   .byte	2
+; CHECK-NEXT:   .byte	0
+; CHECK-NEXT:   .short	8
+; CHECK-NEXT:   .short	6
+; CHECK-NEXT:   .short	0
+; CHECK-NEXT:   .long
+; Loc 1: Direct RBP - ofs
+; CHECK-NEXT:   .byte	2
+; CHECK-NEXT:   .byte   0
+; CHECK-NEXT:   .short  8
+; CHECK-NEXT:   .short	6
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .long
+define void @directFrameIdx() {
+entry:
+  %metadata1 = alloca i64, i32 3, align 8
+  store i64 11, i64* %metadata1
+  store i64 12, i64* %metadata1
+  store i64 13, i64* %metadata1
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 16, i32 0, i64* %metadata1)
+  %metadata2 = alloca i8, i32 4, align 8
+  %metadata3 = alloca i16, i32 4, align 8
+  call void (i64, i32, i8*, i32, ...) @llvm.experimental.patchpoint.void(i64 17, i32 5, i8* null, i32 0, i8* %metadata2, i16* %metadata3)
+  ret void
+}
+
+; Test a 64-bit ID.
+;
+; CHECK:        .quad 4294967295
+; CHECK-LABEL:  .long L{{.*}}-_longid
+; CHECK:        .quad 4294967296
+; CHECK-LABEL:  .long L{{.*}}-_longid
+; CHECK:        .quad 9223372036854775807
+; CHECK-LABEL:  .long L{{.*}}-_longid
+; CHECK:        .quad -1
+; CHECK-LABEL:  .long L{{.*}}-_longid
+define void @longid() {
+entry:
+  tail call void (i64, i32, i8*, i32, ...) @llvm.experimental.patchpoint.void(i64 4294967295, i32 0, i8* null, i32 0)
+  tail call void (i64, i32, i8*, i32, ...) @llvm.experimental.patchpoint.void(i64 4294967296, i32 0, i8* null, i32 0)
+  tail call void (i64, i32, i8*, i32, ...) @llvm.experimental.patchpoint.void(i64 9223372036854775807, i32 0, i8* null, i32 0)
+  tail call void (i64, i32, i8*, i32, ...) @llvm.experimental.patchpoint.void(i64 -1, i32 0, i8* null, i32 0)
+  ret void
+}
+
+; Map a value when R11 is the only free register.
+; The scratch register should not be used for a live stackmap value.
+;
+; CHECK-LABEL:  .long L{{.*}}-_clobberScratch
+; CHECK-NEXT:   .short 0
+; 1 location
+; CHECK-NEXT:   .short 1
+; Loc 0: Indirect fp - offset
+; CHECK-NEXT:   .byte   3
+; CHECK-NEXT:   .byte   0
+; CHECK-NEXT:   .short  4
+; CHECK-NEXT:   .short  6
+; CHECK-NEXT:   .short  0
+; CHECK-NEXT:   .long   -{{[0-9]+}}
+define void @clobberScratch(i32 %a) {
+  tail call void asm sideeffect "nop", "~{ax},~{bx},~{cx},~{dx},~{bp},~{si},~{di},~{r8},~{r9},~{r10},~{r12},~{r13},~{r14},~{r15}"() nounwind
+  tail call void (i64, i32, ...) @llvm.experimental.stackmap(i64 16, i32 8, i32 %a)
+  ret void
+}
+
+; A stack frame which needs to be realigned at runtime (to meet alignment 
+; criteria for values on the stack) does not have a fixed frame size. 
+; CHECK-LABEL:  .long L{{.*}}-_needsStackRealignment
+; CHECK-NEXT:   .short 0
+; 0 locations
+; CHECK-NEXT:   .short 0
+define void @needsStackRealignment() {
+  %val = alloca i64, i32 3, align 128
+  tail call void (...) @escape_values(i64* %val)
+; Note: Adding any non-constant to the stackmap would fail because we
+; expected to be able to address off the frame pointer.  In a realigned
+; frame, we must use the stack pointer instead.  This is a separate bug.
+  tail call void (i64, i32, ...) @llvm.experimental.stackmap(i64 0, i32 0)
+  ret void
+}
+declare void @escape_values(...)
+
+declare void @llvm.experimental.stackmap(i64, i32, ...)
+declare void @llvm.experimental.patchpoint.void(i64, i32, i8*, i32, ...)
+declare i64 @llvm.experimental.patchpoint.i64(i64, i32, i8*, i32, ...)


### PR DESCRIPTION
This PR extends `ykstackmaps` to parse location blocks inside a stackmap record. Stackmap locations are really important for garbage collection. At a given safepoint in a program's runtime, we need a way to identify which live variables are roots to GCable objects. These pointers could be in registers or explicitly spilled to the stack (e.g. `alloca`s in LLVM which were not possible to optimise away with `mem2reg` or `SROA` passes on the IR). The location block lets us tell the collector how to find these values of interest by encoding appropriate metadata about each pointer in the stackmap record.

